### PR TITLE
Map Incoming Documents from opneg2p-portal-api to Corresponding Program Membership IDs

### DIFF
--- a/src/openg2p_portal_api/controllers/document_file_controller.py
+++ b/src/openg2p_portal_api/controllers/document_file_controller.py
@@ -58,7 +58,10 @@ class DocumentFileController(BaseController):
 
         try:
             message = await self.file_service.upload_document(
-                file=file, programid=programid, file_tag=file_tag
+                file=file,
+                programid=programid,
+                file_tag=file_tag,
+                partner_id=auth.partner_id,
             )
             return message
         except Exception:

--- a/src/openg2p_portal_api/models/orm/document_file_orm.py
+++ b/src/openg2p_portal_api/models/orm/document_file_orm.py
@@ -24,6 +24,12 @@ class DocumentFileORM(BaseORMModel):
         ForeignKey("storage_backend.id"), nullable=False, index=True
     )
     company_id: Mapped[int] = mapped_column(ForeignKey("res_partner.id"), nullable=True)
+    program_membership_id: Mapped[int] = mapped_column(
+        ForeignKey("g2p_program_membership.id"), nullable=True
+    )
 
     backend = relationship("DocumentStoreORM", back_populates="documents")
     partner = relationship("PartnerORM", back_populates="documents")
+    program_membership = relationship(
+        "ProgramMembershipORM", back_populates="document_files"
+    )

--- a/src/openg2p_portal_api/models/orm/program_membership_orm.py
+++ b/src/openg2p_portal_api/models/orm/program_membership_orm.py
@@ -7,6 +7,8 @@ from sqlalchemy import DateTime, ForeignKey, Integer, String, and_, select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from openg2p_portal_api.models.orm.document_file_orm import DocumentFileORM
+
 from .program_registrant_info_orm import ProgramRegistrantInfoORM
 
 
@@ -22,6 +24,9 @@ class ProgramMembershipORM(BaseORMModel):
     program = relationship("ProgramORM", back_populates="membership")
     program_reg_info: Mapped[Optional[List["ProgramRegistrantInfoORM"]]] = relationship(
         back_populates="membership"
+    )
+    document_files: Mapped[Optional[List["DocumentFileORM"]]] = relationship(
+        back_populates="program_membership"
     )
 
     @classmethod


### PR DESCRIPTION
This pull request implements the mapping of incoming documents from the opneg2p-portal-api to the corresponding program membership IDs. The goal is to ensure that each document is accurately associated with the appropriate program membership, allowing for better tracking, processing, and organization of the data.